### PR TITLE
update blockstack.js to 0.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,7837 @@
+{
+  "name": "hello-blockstack-nth-time",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+      "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+      "dev": true,
+      "requires": {
+        "mime-types": "2.1.15",
+        "negotiator": "0.6.1"
+      }
+    },
+    "acorn": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+      "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+      "dev": true
+    },
+    "array-filter": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
+      "dev": true
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-map": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
+      "dev": true
+    },
+    "array-reduce": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
+      "dev": true
+    },
+    "asn1.js": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+      "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "assert": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "dev": true,
+      "requires": {
+        "util": "0.10.3"
+      }
+    },
+    "astw": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
+      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "base64-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+      "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+      "dev": true
+    },
+    "blockstack": {
+      "version": "file:../blockstack.js",
+      "requires": {
+        "ajv": "4.11.8",
+        "bitcoinjs-lib": "2.3.0",
+        "blockstack-storage": "0.2.6",
+        "custom-protocol-detection-blockstack": "1.1.3",
+        "ecurve": "1.0.5",
+        "elliptic": "6.4.0",
+        "es6-promise": "4.1.0",
+        "hasprop": "0.0.4",
+        "isomorphic-fetch": "2.2.1",
+        "jsontokens": "0.7.6",
+        "promise": "7.1.1",
+        "query-string": "4.3.4",
+        "request": "2.81.0",
+        "schema-inspector": "1.6.8",
+        "sprintf-js": "1.0.3",
+        "uuid": "3.0.1",
+        "validator": "7.0.0",
+        "zone-file": "0.2.2"
+      },
+      "dependencies": {
+        "accepts": {
+          "version": "1.3.3",
+          "bundled": true,
+          "requires": {
+            "mime-types": "2.1.15",
+            "negotiator": "0.6.1"
+          }
+        },
+        "acorn": {
+          "version": "4.0.11",
+          "bundled": true
+        },
+        "acorn-jsx": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "acorn": "3.3.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "3.3.0",
+              "bundled": true
+            }
+          }
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ajv-keywords": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "ansi-html": {
+          "version": "0.0.7",
+          "bundled": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "bundled": true
+        },
+        "anymatch": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "arrify": "1.0.1",
+            "micromatch": "2.3.11"
+          }
+        },
+        "argparse": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        },
+        "arr-diff": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "arr-flatten": "1.0.3"
+          }
+        },
+        "arr-flatten": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-filter": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "array-flatten": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "array-iterate": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "array-map": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "array-reduce": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "array-union": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "array-uniq": "1.0.3"
+          }
+        },
+        "array-uniq": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "array-unique": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "arrify": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asap": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "asn1.js": {
+          "version": "4.9.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0"
+          }
+        },
+        "assert": {
+          "version": "1.4.1",
+          "bundled": true,
+          "requires": {
+            "util": "0.10.3"
+          }
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "astw": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "4.0.11"
+          }
+        },
+        "async": {
+          "version": "1.5.2",
+          "bundled": true
+        },
+        "async-each": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true
+        },
+        "babel-cli": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.24.1",
+            "babel-polyfill": "6.23.0",
+            "babel-register": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "chokidar": "1.7.0",
+            "commander": "2.10.0",
+            "convert-source-map": "1.5.0",
+            "fs-readdir-recursive": "1.0.0",
+            "glob": "7.1.1",
+            "lodash": "4.17.4",
+            "output-file-sync": "1.1.2",
+            "path-is-absolute": "1.0.1",
+            "slash": "1.0.0",
+            "source-map": "0.5.6",
+            "v8flags": "2.1.1"
+          }
+        },
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.1"
+          }
+        },
+        "babel-core": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "babel-generator": "6.24.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "convert-source-map": "1.5.0",
+            "debug": "2.6.6",
+            "json5": "0.5.1",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.3",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.7",
+            "slash": "1.0.0",
+            "source-map": "0.5.6"
+          }
+        },
+        "babel-eslint": {
+          "version": "6.1.2",
+          "bundled": true,
+          "requires": {
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "lodash.assign": "4.2.0",
+            "lodash.pickby": "4.6.0"
+          }
+        },
+        "babel-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.4",
+            "source-map": "0.5.6",
+            "trim-right": "1.0.1"
+          }
+        },
+        "babel-helper-bindify-decorators": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-builder-binary-assignment-operator-visitor": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-assignable-expression": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-builder-react-jsx": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "esutils": "2.0.2"
+          }
+        },
+        "babel-helper-call-delegate": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-define-map": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-explode-assignable-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-explode-class": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-bindify-decorators": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-get-function-arity": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-hoist-variables": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-optimise-call-expression": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-helper-remap-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helper-replace-supers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-syntax-async-functions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-async-generators": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-constructor-call": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-class-properties": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-decorators": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-do-expressions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-dynamic-import": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-exponentiation-operator": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-export-extensions": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-flow": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-function-bind": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-object-rest-spread": {
+          "version": "6.13.0",
+          "bundled": true
+        },
+        "babel-plugin-syntax-trailing-function-commas": {
+          "version": "6.22.0",
+          "bundled": true
+        },
+        "babel-plugin-system-import-transformer": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-dynamic-import": "6.18.0"
+          }
+        },
+        "babel-plugin-transform-async-generator-functions": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "6.24.1",
+            "babel-plugin-syntax-async-generators": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-async-to-generator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-remap-async-to-generator": "6.24.1",
+            "babel-plugin-syntax-async-functions": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-class-constructor-call": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-class-constructor-call": "6.18.0",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-class-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-plugin-syntax-class-properties": "6.13.0",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-decorators": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-explode-class": "6.24.1",
+            "babel-plugin-syntax-decorators": "6.13.0",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-decorators-legacy": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-decorators": "6.13.0",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-do-expressions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-do-expressions": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-define-map": "6.24.1",
+            "babel-helper-function-name": "6.24.1",
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-strict-mode": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-call-delegate": "6.24.1",
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-template": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-regex": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "regexpu-core": "2.0.0"
+          }
+        },
+        "babel-plugin-transform-exponentiation-operator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-export-extensions": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-export-extensions": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-flow-strip-types": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-flow": "6.18.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-function-bind": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-function-bind": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-object-rest-spread": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-object-rest-spread": "6.13.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.25.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-helper-builder-react-jsx": "6.24.1",
+            "babel-plugin-syntax-jsx": "6.18.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "6.18.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.22.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "6.18.0",
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "regenerator-transform": "0.9.11"
+          }
+        },
+        "babel-plugin-transform-strict-mode": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1"
+          }
+        },
+        "babel-polyfill": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
+        },
+        "babel-preset-es2015": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.24.1",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+            "babel-plugin-transform-es2015-object-super": "6.24.1",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-regenerator": "6.24.1"
+          }
+        },
+        "babel-preset-flow": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-flow-strip-types": "6.22.0"
+          }
+        },
+        "babel-preset-react": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-jsx": "6.18.0",
+            "babel-plugin-transform-react-display-name": "6.25.0",
+            "babel-plugin-transform-react-jsx": "6.24.1",
+            "babel-plugin-transform-react-jsx-self": "6.22.0",
+            "babel-plugin-transform-react-jsx-source": "6.22.0",
+            "babel-preset-flow": "6.23.0"
+          }
+        },
+        "babel-preset-stage-0": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-do-expressions": "6.22.0",
+            "babel-plugin-transform-function-bind": "6.22.0",
+            "babel-preset-stage-1": "6.24.1"
+          }
+        },
+        "babel-preset-stage-1": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-transform-class-constructor-call": "6.24.1",
+            "babel-plugin-transform-export-extensions": "6.22.0",
+            "babel-preset-stage-2": "6.24.1"
+          }
+        },
+        "babel-preset-stage-2": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-dynamic-import": "6.18.0",
+            "babel-plugin-transform-class-properties": "6.24.1",
+            "babel-plugin-transform-decorators": "6.24.1",
+            "babel-preset-stage-3": "6.24.1"
+          }
+        },
+        "babel-preset-stage-3": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-async-generator-functions": "6.24.1",
+            "babel-plugin-transform-async-to-generator": "6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "6.24.1",
+            "babel-plugin-transform-object-rest-spread": "6.23.0"
+          }
+        },
+        "babel-register": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.24.1",
+            "babel-runtime": "6.23.0",
+            "core-js": "2.4.1",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "source-map-support": "0.4.15"
+          }
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "bundled": true,
+          "requires": {
+            "core-js": "2.4.1",
+            "regenerator-runtime": "0.10.5"
+          }
+        },
+        "babel-template": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-traverse": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-code-frame": "6.22.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "babylon": "6.17.0",
+            "debug": "2.6.6",
+            "globals": "9.17.0",
+            "invariant": "2.2.2",
+            "lodash": "4.17.4"
+          }
+        },
+        "babel-types": {
+          "version": "6.24.1",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.4",
+            "to-fast-properties": "1.0.3"
+          }
+        },
+        "babelify": {
+          "version": "7.3.0",
+          "bundled": true,
+          "requires": {
+            "babel-core": "6.24.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "babylon": {
+          "version": "6.17.0",
+          "bundled": true
+        },
+        "bail": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "base-x": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "base64url": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "bigi": {
+          "version": "1.4.2",
+          "bundled": true
+        },
+        "binary-extensions": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "bip66": {
+          "version": "1.1.4",
+          "bundled": true
+        },
+        "bitcoinjs-lib": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "bigi": "1.4.2",
+            "bip66": "1.1.4",
+            "bs58check": "1.3.4",
+            "buffer-compare": "1.1.1",
+            "buffer-equals": "1.0.4",
+            "buffer-reverse": "1.0.1",
+            "create-hash": "1.1.2",
+            "create-hmac": "1.1.4",
+            "ecurve": "1.0.5",
+            "randombytes": "2.0.3",
+            "typeforce": "1.11.1",
+            "wif": "2.0.6"
+          }
+        },
+        "blockstack-storage": {
+          "version": "0.2.6",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "bitcoinjs-lib": "2.3.0",
+            "elliptic": "6.4.0",
+            "isomorphic-fetch": "2.2.1",
+            "jsontokens": "0.7.6",
+            "uuid": "3.0.1"
+          }
+        },
+        "blue-tape": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "tape": "4.6.3"
+          }
+        },
+        "bn.js": {
+          "version": "4.11.6",
+          "bundled": true
+        },
+        "body": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "continuable-cache": "0.3.1",
+            "error": "7.0.2",
+            "raw-body": "1.1.7",
+            "safe-json-parse": "1.0.1"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "braces": {
+          "version": "1.8.5",
+          "bundled": true,
+          "requires": {
+            "expand-range": "1.8.2",
+            "preserve": "0.2.0",
+            "repeat-element": "1.1.2"
+          }
+        },
+        "brorand": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "browser-pack": {
+          "version": "6.0.2",
+          "bundled": true,
+          "requires": {
+            "combine-source-map": "0.7.2",
+            "defined": "1.0.0",
+            "JSONStream": "1.3.1",
+            "through2": "2.0.3",
+            "umd": "3.0.1"
+          }
+        },
+        "browser-resolve": {
+          "version": "1.11.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          }
+        },
+        "browserify": {
+          "version": "13.3.0",
+          "bundled": true,
+          "requires": {
+            "assert": "1.4.1",
+            "browser-pack": "6.0.2",
+            "browser-resolve": "1.11.2",
+            "browserify-zlib": "0.1.4",
+            "buffer": "4.9.1",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.5.2",
+            "console-browserify": "1.1.0",
+            "constants-browserify": "1.0.0",
+            "crypto-browserify": "3.11.0",
+            "defined": "1.0.0",
+            "deps-sort": "2.0.0",
+            "domain-browser": "1.1.7",
+            "duplexer2": "0.1.4",
+            "events": "1.1.1",
+            "glob": "7.1.1",
+            "has": "1.0.1",
+            "htmlescape": "1.1.1",
+            "https-browserify": "0.0.1",
+            "inherits": "2.0.3",
+            "insert-module-globals": "7.0.1",
+            "JSONStream": "1.3.1",
+            "labeled-stream-splicer": "2.0.0",
+            "module-deps": "4.1.1",
+            "os-browserify": "0.1.2",
+            "parents": "1.0.1",
+            "path-browserify": "0.0.0",
+            "process": "0.11.10",
+            "punycode": "1.4.1",
+            "querystring-es3": "0.2.1",
+            "read-only-stream": "2.0.0",
+            "readable-stream": "2.2.9",
+            "resolve": "1.1.7",
+            "shasum": "1.0.2",
+            "shell-quote": "1.6.1",
+            "stream-browserify": "2.0.1",
+            "stream-http": "2.7.0",
+            "string_decoder": "0.10.31",
+            "subarg": "1.0.0",
+            "syntax-error": "1.3.0",
+            "through2": "2.0.3",
+            "timers-browserify": "1.4.2",
+            "tty-browserify": "0.0.0",
+            "url": "0.11.0",
+            "util": "0.10.3",
+            "vm-browserify": "0.0.4",
+            "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "browserify-aes": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "buffer-xor": "1.0.3",
+            "cipher-base": "1.0.3",
+            "create-hash": "1.1.2",
+            "evp_bytestokey": "1.0.0",
+            "inherits": "2.0.3"
+          }
+        },
+        "browserify-cipher": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "browserify-aes": "1.0.6",
+            "browserify-des": "1.0.0",
+            "evp_bytestokey": "1.0.0"
+          }
+        },
+        "browserify-des": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "1.0.3",
+            "des.js": "1.0.0",
+            "inherits": "2.0.3"
+          }
+        },
+        "browserify-rsa": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "randombytes": "2.0.3"
+          }
+        },
+        "browserify-sign": {
+          "version": "4.0.4",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.1.2",
+            "create-hmac": "1.1.4",
+            "elliptic": "6.4.0",
+            "inherits": "2.0.3",
+            "parse-asn1": "5.1.0"
+          }
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "pako": "0.2.9"
+          }
+        },
+        "bs58": {
+          "version": "3.1.0",
+          "bundled": true,
+          "requires": {
+            "base-x": "1.1.0"
+          }
+        },
+        "bs58check": {
+          "version": "1.3.4",
+          "bundled": true,
+          "requires": {
+            "bs58": "3.1.0",
+            "create-hash": "1.1.2"
+          }
+        },
+        "buffer": {
+          "version": "4.9.1",
+          "bundled": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "ieee754": "1.1.8",
+            "isarray": "1.0.0"
+          }
+        },
+        "buffer-compare": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "buffer-equals": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "buffer-reverse": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "buffer-xor": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "builtin-status-codes": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "bytes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cached-path-relative": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "caller-path": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "callsites": "0.2.0"
+          }
+        },
+        "callsites": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true
+        },
+        "ccount": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "character-entities": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "character-entities-html4": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "character-entities-legacy": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "character-reference-invalid": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "chokidar": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "anymatch": "1.3.0",
+            "async-each": "1.0.1",
+            "fsevents": "1.1.2",
+            "glob-parent": "2.0.0",
+            "inherits": "2.0.3",
+            "is-binary-path": "1.0.1",
+            "is-glob": "2.0.1",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.1.0"
+          }
+        },
+        "cipher-base": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "circular-json": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cli-cursor": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "restore-cursor": "1.0.1"
+          }
+        },
+        "cli-width": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "clone": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "clone-buffer": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "clone-stats": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "cloneable-readable": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "process-nextick-args": "1.0.7",
+            "through2": "2.0.3"
+          }
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "collapse-white-space": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "combine-source-map": {
+          "version": "0.7.2",
+          "bundled": true,
+          "requires": {
+            "convert-source-map": "1.1.3",
+            "inline-source-map": "0.6.2",
+            "lodash.memoize": "3.0.4",
+            "source-map": "0.5.6"
+          },
+          "dependencies": {
+            "convert-source-map": {
+              "version": "1.1.3",
+              "bundled": true
+            }
+          }
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "comma-separated-tokens": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "trim": "0.0.1"
+          }
+        },
+        "commander": {
+          "version": "2.10.0",
+          "bundled": true,
+          "requires": {
+            "graceful-readlink": "1.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "concat-stream": {
+          "version": "1.5.2",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.0.6",
+            "typedarray": "0.0.6"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.0.6",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "date-now": "0.1.4"
+          }
+        },
+        "constants-browserify": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "contains-path": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "content-disposition": {
+          "version": "0.5.2",
+          "bundled": true
+        },
+        "content-type": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "continuable-cache": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "bundled": true
+        },
+        "cookie": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "bundled": true
+        },
+        "core-js": {
+          "version": "2.4.1",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "create-ecdh": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "elliptic": "6.4.0"
+          }
+        },
+        "create-hash": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "cipher-base": "1.0.3",
+            "inherits": "2.0.3",
+            "ripemd160": "1.0.1",
+            "sha.js": "2.4.8"
+          }
+        },
+        "create-hmac": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "create-hash": "1.1.2",
+            "inherits": "2.0.3"
+          }
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "crypto": {
+          "version": "0.0.3",
+          "bundled": true
+        },
+        "crypto-browserify": {
+          "version": "3.11.0",
+          "bundled": true,
+          "requires": {
+            "browserify-cipher": "1.0.0",
+            "browserify-sign": "4.0.4",
+            "create-ecdh": "4.0.0",
+            "create-hash": "1.1.2",
+            "create-hmac": "1.1.4",
+            "diffie-hellman": "5.0.2",
+            "inherits": "2.0.3",
+            "pbkdf2": "3.0.9",
+            "public-encrypt": "4.0.0",
+            "randombytes": "2.0.3"
+          }
+        },
+        "custom-protocol-detection": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "custom-protocol-detection-blockstack": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "d": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "es5-ext": "0.10.15"
+          }
+        },
+        "damerau-levenshtein": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "date-now": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "debug": {
+          "version": "2.6.6",
+          "bundled": true,
+          "requires": {
+            "ms": "0.7.3"
+          }
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "deep-equal": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "deep-is": {
+          "version": "0.1.3",
+          "bundled": true
+        },
+        "define-properties": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "foreach": "2.0.5",
+            "object-keys": "1.0.11"
+          }
+        },
+        "defined": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "del": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.0",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "depd": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "deps-sort": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "JSONStream": "1.3.1",
+            "shasum": "1.0.2",
+            "subarg": "1.0.0",
+            "through2": "2.0.3"
+          }
+        },
+        "des.js": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0"
+          }
+        },
+        "destroy": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "detab": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "repeat-string": "1.6.1"
+          }
+        },
+        "detect-indent": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "repeating": "2.0.1"
+          }
+        },
+        "detective": {
+          "version": "4.5.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "4.0.11",
+            "defined": "1.0.0"
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "bundled": true
+        },
+        "diffie-hellman": {
+          "version": "5.0.2",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "miller-rabin": "4.0.0",
+            "randombytes": "2.0.3"
+          }
+        },
+        "disparity": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "diff": "1.4.0"
+          }
+        },
+        "doctrine": {
+          "version": "1.5.0",
+          "bundled": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        },
+        "doctrine-temporary-fork": {
+          "version": "2.0.0-alpha-allowarrayindex",
+          "bundled": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        },
+        "documentation": {
+          "version": "4.0.0-rc.1",
+          "bundled": true,
+          "requires": {
+            "ansi-html": "0.0.7",
+            "babel-core": "6.24.1",
+            "babel-generator": "6.24.1",
+            "babel-plugin-system-import-transformer": "3.1.0",
+            "babel-plugin-transform-decorators-legacy": "1.3.4",
+            "babel-preset-es2015": "6.24.1",
+            "babel-preset-react": "6.24.1",
+            "babel-preset-stage-0": "6.24.1",
+            "babel-traverse": "6.24.1",
+            "babel-types": "6.24.1",
+            "babelify": "7.3.0",
+            "babylon": "6.17.0",
+            "chalk": "1.1.3",
+            "chokidar": "1.7.0",
+            "concat-stream": "1.5.2",
+            "disparity": "2.0.0",
+            "doctrine-temporary-fork": "2.0.0-alpha-allowarrayindex",
+            "get-comments": "1.0.1",
+            "git-url-parse": "6.2.2",
+            "github-slugger": "1.1.1",
+            "glob": "7.1.1",
+            "globals-docs": "2.3.0",
+            "highlight.js": "9.12.0",
+            "js-yaml": "3.8.4",
+            "lodash": "4.17.4",
+            "mdast-util-inject": "1.1.0",
+            "micromatch": "2.3.11",
+            "mime": "1.3.4",
+            "module-deps-sortable": "4.0.6",
+            "parse-filepath": "1.0.1",
+            "pify": "2.3.0",
+            "read-pkg-up": "2.0.0",
+            "remark": "7.0.1",
+            "remark-html": "6.0.0",
+            "remark-toc": "4.0.1",
+            "remote-origin-url": "0.4.0",
+            "shelljs": "0.7.8",
+            "stream-array": "1.1.2",
+            "strip-json-comments": "2.0.1",
+            "tiny-lr": "1.0.5",
+            "unist-builder": "1.0.2",
+            "unist-util-visit": "1.1.3",
+            "vfile": "2.1.0",
+            "vfile-reporter": "3.0.0",
+            "vfile-sort": "2.0.0",
+            "vinyl": "2.1.0",
+            "vinyl-fs": "2.4.4",
+            "yargs": "6.6.0"
+          },
+          "dependencies": {
+            "module-deps-sortable": {
+              "version": "4.0.6",
+              "bundled": true,
+              "requires": {
+                "browser-resolve": "1.11.2",
+                "concat-stream": "1.5.2",
+                "defined": "1.0.0",
+                "detective": "4.5.0",
+                "duplexer2": "0.1.4",
+                "inherits": "2.0.3",
+                "JSONStream": "1.3.1",
+                "parents": "1.0.1",
+                "readable-stream": "2.2.9",
+                "resolve": "1.1.7",
+                "stream-combiner2": "1.1.1",
+                "subarg": "1.0.0",
+                "through2": "2.0.3",
+                "xtend": "4.0.1"
+              }
+            },
+            "shelljs": {
+              "version": "0.7.8",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.1",
+                "interpret": "1.0.3",
+                "rechoir": "0.6.2"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "duplexer2": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.2.9"
+          }
+        },
+        "duplexify": {
+          "version": "3.5.0",
+          "bundled": true,
+          "requires": {
+            "end-of-stream": "1.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.2.9",
+            "stream-shift": "1.0.0"
+          }
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "ecurve": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "bigi": "1.4.2"
+          }
+        },
+        "ee-first": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "elliptic": {
+          "version": "6.4.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "brorand": "1.1.0",
+            "hash.js": "1.0.3",
+            "hmac-drbg": "1.0.1",
+            "inherits": "2.0.3",
+            "minimalistic-assert": "1.0.0",
+            "minimalistic-crypto-utils": "1.0.1"
+          }
+        },
+        "emoji-regex": {
+          "version": "6.4.3",
+          "bundled": true
+        },
+        "encodeurl": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "encoding": {
+          "version": "0.1.12",
+          "bundled": true,
+          "requires": {
+            "iconv-lite": "0.4.17"
+          }
+        },
+        "end-of-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "once": "1.3.3"
+          },
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            }
+          }
+        },
+        "error": {
+          "version": "7.0.2",
+          "bundled": true,
+          "requires": {
+            "string-template": "0.2.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "es-abstract": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "es-to-primitive": "1.1.1",
+            "function-bind": "1.1.0",
+            "is-callable": "1.1.3",
+            "is-regex": "1.0.4"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "is-callable": "1.1.3",
+            "is-date-object": "1.0.1",
+            "is-symbol": "1.0.1"
+          }
+        },
+        "es5-ext": {
+          "version": "0.10.15",
+          "bundled": true,
+          "requires": {
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-iterator": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.15",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "es6-map": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.15",
+            "es6-iterator": "2.0.1",
+            "es6-set": "0.1.5",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-promise": {
+          "version": "4.1.0",
+          "bundled": true
+        },
+        "es6-set": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.15",
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1",
+            "event-emitter": "0.3.5"
+          }
+        },
+        "es6-symbol": {
+          "version": "3.1.1",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.15"
+          }
+        },
+        "es6-weak-map": {
+          "version": "2.0.2",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.15",
+            "es6-iterator": "2.0.1",
+            "es6-symbol": "3.1.1"
+          }
+        },
+        "escape-html": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "escope": {
+          "version": "3.6.0",
+          "bundled": true,
+          "requires": {
+            "es6-map": "0.1.5",
+            "es6-weak-map": "2.0.2",
+            "esrecurse": "4.1.0",
+            "estraverse": "4.2.0"
+          }
+        },
+        "eslint": {
+          "version": "2.13.1",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "concat-stream": "1.5.2",
+            "debug": "2.6.6",
+            "doctrine": "1.5.0",
+            "es6-map": "0.1.5",
+            "escope": "3.6.0",
+            "espree": "3.4.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "file-entry-cache": "1.3.1",
+            "glob": "7.1.1",
+            "globals": "9.17.0",
+            "ignore": "3.3.0",
+            "imurmurhash": "0.1.4",
+            "inquirer": "0.12.0",
+            "is-my-json-valid": "2.16.0",
+            "is-resolvable": "1.0.0",
+            "js-yaml": "3.8.4",
+            "json-stable-stringify": "1.0.1",
+            "levn": "0.3.0",
+            "lodash": "4.17.4",
+            "mkdirp": "0.5.1",
+            "optionator": "0.8.2",
+            "path-is-absolute": "1.0.1",
+            "path-is-inside": "1.0.2",
+            "pluralize": "1.2.1",
+            "progress": "1.1.8",
+            "require-uncached": "1.0.3",
+            "shelljs": "0.6.1",
+            "strip-json-comments": "1.0.4",
+            "table": "3.8.3",
+            "text-table": "0.2.0",
+            "user-home": "2.0.0"
+          },
+          "dependencies": {
+            "user-home": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "os-homedir": "1.0.2"
+              }
+            }
+          }
+        },
+        "eslint-config-airbnb": {
+          "version": "9.0.1",
+          "bundled": true,
+          "requires": {
+            "eslint-config-airbnb-base": "3.0.1"
+          }
+        },
+        "eslint-config-airbnb-base": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "eslint-import-resolver-node": {
+          "version": "0.2.3",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.6",
+            "object-assign": "4.1.1",
+            "resolve": "1.1.7"
+          }
+        },
+        "eslint-plugin-import": {
+          "version": "1.16.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1",
+            "contains-path": "0.1.0",
+            "debug": "2.6.6",
+            "doctrine": "1.3.0",
+            "es6-map": "0.1.5",
+            "es6-set": "0.1.5",
+            "eslint-import-resolver-node": "0.2.3",
+            "has": "1.0.1",
+            "lodash.cond": "4.5.2",
+            "lodash.endswith": "4.2.1",
+            "lodash.find": "4.6.0",
+            "lodash.findindex": "4.6.0",
+            "minimatch": "3.0.3",
+            "object-assign": "4.1.1",
+            "pkg-dir": "1.0.0",
+            "pkg-up": "1.0.0"
+          },
+          "dependencies": {
+            "doctrine": {
+              "version": "1.3.0",
+              "bundled": true,
+              "requires": {
+                "esutils": "2.0.2",
+                "isarray": "1.0.0"
+              }
+            }
+          }
+        },
+        "eslint-plugin-jsx-a11y": {
+          "version": "1.5.5",
+          "bundled": true,
+          "requires": {
+            "damerau-levenshtein": "1.0.4",
+            "jsx-ast-utils": "1.4.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "eslint-plugin-react": {
+          "version": "5.2.2",
+          "bundled": true,
+          "requires": {
+            "doctrine": "1.5.0",
+            "jsx-ast-utils": "1.4.1"
+          }
+        },
+        "espree": {
+          "version": "3.4.3",
+          "bundled": true,
+          "requires": {
+            "acorn": "5.0.3",
+            "acorn-jsx": "3.0.1"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "5.0.3",
+              "bundled": true
+            }
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "bundled": true
+        },
+        "esrecurse": {
+          "version": "4.1.0",
+          "bundled": true,
+          "requires": {
+            "estraverse": "4.1.1",
+            "object-assign": "4.1.1"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "4.1.1",
+              "bundled": true
+            }
+          }
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "bundled": true
+        },
+        "etag": {
+          "version": "1.8.0",
+          "bundled": true
+        },
+        "event-emitter": {
+          "version": "0.3.5",
+          "bundled": true,
+          "requires": {
+            "d": "1.0.0",
+            "es5-ext": "0.10.15"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "evp_bytestokey": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "create-hash": "1.1.2"
+          }
+        },
+        "exit-hook": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "expand-brackets": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "is-posix-bracket": "0.1.1"
+          }
+        },
+        "expand-range": {
+          "version": "1.8.2",
+          "bundled": true,
+          "requires": {
+            "fill-range": "2.2.3"
+          }
+        },
+        "express": {
+          "version": "4.15.2",
+          "bundled": true,
+          "requires": {
+            "accepts": "1.3.3",
+            "array-flatten": "1.1.1",
+            "content-disposition": "0.5.2",
+            "content-type": "1.0.2",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.1",
+            "depd": "1.1.0",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.0",
+            "finalhandler": "1.0.2",
+            "fresh": "0.5.0",
+            "merge-descriptors": "1.0.1",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.1",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "1.1.4",
+            "qs": "6.4.0",
+            "range-parser": "1.2.0",
+            "send": "0.15.1",
+            "serve-static": "1.12.1",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1",
+            "type-is": "1.6.15",
+            "utils-merge": "1.0.0",
+            "vary": "1.1.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "ms": "0.7.2"
+              }
+            },
+            "ms": {
+              "version": "0.7.2",
+              "bundled": true
+            }
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "extend-shallow": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extendable": "0.1.1"
+          }
+        },
+        "extglob": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "fast-levenshtein": {
+          "version": "2.0.6",
+          "bundled": true
+        },
+        "faye-websocket": {
+          "version": "0.10.0",
+          "bundled": true,
+          "requires": {
+            "websocket-driver": "0.6.5"
+          }
+        },
+        "fetch-mock": {
+          "version": "5.10.0",
+          "bundled": true,
+          "requires": {
+            "glob-to-regexp": "0.3.0",
+            "node-fetch": "1.6.3",
+            "path-to-regexp": "1.7.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "path-to-regexp": {
+              "version": "1.7.0",
+              "bundled": true,
+              "requires": {
+                "isarray": "0.0.1"
+              }
+            }
+          }
+        },
+        "figures": {
+          "version": "1.7.0",
+          "bundled": true,
+          "requires": {
+            "escape-string-regexp": "1.0.5",
+            "object-assign": "4.1.1"
+          }
+        },
+        "file-entry-cache": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "flat-cache": "1.2.2",
+            "object-assign": "4.1.1"
+          }
+        },
+        "filename-regex": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "fill-range": {
+          "version": "2.2.3",
+          "bundled": true,
+          "requires": {
+            "is-number": "2.1.0",
+            "isobject": "2.1.0",
+            "randomatic": "1.1.7",
+            "repeat-element": "1.1.2",
+            "repeat-string": "1.6.1"
+          }
+        },
+        "finalhandler": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.1",
+            "statuses": "1.3.1",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.4",
+              "bundled": true,
+              "requires": {
+                "ms": "0.7.3"
+              }
+            }
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "first-chunk-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "flat-cache": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "circular-json": "0.3.1",
+            "del": "2.2.2",
+            "graceful-fs": "4.1.11",
+            "write": "0.2.1"
+          }
+        },
+        "flow-bin": {
+          "version": "0.49.1",
+          "bundled": true
+        },
+        "for-each": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "is-function": "1.0.1"
+          }
+        },
+        "for-in": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "for-own": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "for-in": "1.0.2"
+          }
+        },
+        "foreach": {
+          "version": "2.0.5",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "forwarded": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "fresh": {
+          "version": "0.5.0",
+          "bundled": true
+        },
+        "fs-readdir-recursive": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fsevents": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "2.6.2",
+            "node-pre-gyp": "0.6.36"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ajv": {
+              "version": "4.11.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "co": "4.6.0",
+                "json-stable-stringify": "1.0.1"
+              }
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "aproba": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "1.0.0",
+                "readable-stream": "2.2.9"
+              }
+            },
+            "asn1": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "assert-plus": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "asynckit": {
+              "version": "0.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws-sign2": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "balanced-match": {
+              "version": "0.4.2",
+              "bundled": true
+            },
+            "bcrypt-pbkdf": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "tweetnacl": "0.14.5"
+              }
+            },
+            "block-stream": {
+              "version": "0.0.9",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3"
+              }
+            },
+            "boom": {
+              "version": "2.10.1",
+              "bundled": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "brace-expansion": {
+              "version": "1.1.7",
+              "bundled": true,
+              "requires": {
+                "balanced-match": "0.4.2",
+                "concat-map": "0.0.1"
+              }
+            },
+            "buffer-shims": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "bundled": true,
+              "optional": true
+            },
+            "co": {
+              "version": "4.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "bundled": true,
+              "requires": {
+                "delayed-stream": "1.0.0"
+              }
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "cryptiles": {
+              "version": "2.0.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "boom": "2.10.1"
+              }
+            },
+            "dashdash": {
+              "version": "1.14.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "deep-extend": {
+              "version": "0.4.2",
+              "bundled": true,
+              "optional": true
+            },
+            "delayed-stream": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "ecc-jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "extsprintf": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "bundled": true,
+              "optional": true
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asynckit": "0.4.0",
+                "combined-stream": "1.0.5",
+                "mime-types": "2.1.15"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "fstream": {
+              "version": "1.0.11",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "inherits": "2.0.3",
+                "mkdirp": "0.5.1",
+                "rimraf": "2.6.1"
+              }
+            },
+            "fstream-ignore": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fstream": "1.0.11",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4"
+              }
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "1.1.1",
+                "console-control-strings": "1.1.0",
+                "has-unicode": "2.0.1",
+                "object-assign": "4.1.1",
+                "signal-exit": "3.0.2",
+                "string-width": "1.0.2",
+                "strip-ansi": "3.0.1",
+                "wide-align": "1.1.2"
+              }
+            },
+            "getpass": {
+              "version": "0.1.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "glob": {
+              "version": "7.1.2",
+              "bundled": true,
+              "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "bundled": true
+            },
+            "har-schema": {
+              "version": "1.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ajv": "4.11.8",
+                "har-schema": "1.0.5"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "boom": "2.10.1",
+                "cryptiles": "2.0.5",
+                "hoek": "2.16.3",
+                "sntp": "1.0.9"
+              }
+            },
+            "hoek": {
+              "version": "2.16.3",
+              "bundled": true
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "0.2.0",
+                "jsprim": "1.4.0",
+                "sshpk": "1.13.0"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "bundled": true
+            },
+            "ini": {
+              "version": "1.3.4",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "requires": {
+                "number-is-nan": "1.0.1"
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "jodid25519": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsbn": "0.1.1"
+              }
+            },
+            "jsbn": {
+              "version": "0.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "json-schema": {
+              "version": "0.2.3",
+              "bundled": true,
+              "optional": true
+            },
+            "json-stable-stringify": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "jsonify": {
+              "version": "0.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "jsprim": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "assert-plus": "1.0.0",
+                "extsprintf": "1.0.2",
+                "json-schema": "0.2.3",
+                "verror": "1.3.6"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "mime-db": {
+              "version": "1.27.0",
+              "bundled": true
+            },
+            "mime-types": {
+              "version": "2.1.15",
+              "bundled": true,
+              "requires": {
+                "mime-db": "1.27.0"
+              }
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "requires": {
+                "brace-expansion": "1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "bundled": true,
+              "requires": {
+                "minimist": "0.0.8"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "node-pre-gyp": {
+              "version": "0.6.36",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "mkdirp": "0.5.1",
+                "nopt": "4.0.1",
+                "npmlog": "4.1.0",
+                "rc": "1.2.1",
+                "request": "2.81.0",
+                "rimraf": "2.6.1",
+                "semver": "5.3.0",
+                "tar": "2.2.1",
+                "tar-pack": "3.4.0"
+              }
+            },
+            "nopt": {
+              "version": "4.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1.1.0",
+                "osenv": "0.1.4"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "1.1.4",
+                "console-control-strings": "1.1.0",
+                "gauge": "2.7.4",
+                "set-blocking": "2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "requires": {
+                "wrappy": "1.0.2"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "1.0.2",
+                "os-tmpdir": "1.0.2"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "1.0.7",
+              "bundled": true
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "bundled": true,
+              "optional": true
+            },
+            "qs": {
+              "version": "6.4.0",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "0.4.2",
+                "ini": "1.3.4",
+                "minimist": "1.2.0",
+                "strip-json-comments": "2.0.1"
+              },
+              "dependencies": {
+                "minimist": {
+                  "version": "1.2.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.2.9",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "1.0.1",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "request": {
+              "version": "2.81.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aws-sign2": "0.6.0",
+                "aws4": "1.6.0",
+                "caseless": "0.12.0",
+                "combined-stream": "1.0.5",
+                "extend": "3.0.1",
+                "forever-agent": "0.6.1",
+                "form-data": "2.1.4",
+                "har-validator": "4.2.1",
+                "hawk": "3.1.3",
+                "http-signature": "1.1.1",
+                "is-typedarray": "1.0.0",
+                "isstream": "0.1.2",
+                "json-stringify-safe": "5.0.1",
+                "mime-types": "2.1.15",
+                "oauth-sign": "0.8.2",
+                "performance-now": "0.2.0",
+                "qs": "6.4.0",
+                "safe-buffer": "5.0.1",
+                "stringstream": "0.0.5",
+                "tough-cookie": "2.3.2",
+                "tunnel-agent": "0.6.0",
+                "uuid": "3.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "glob": "7.1.2"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.0.1",
+              "bundled": true
+            },
+            "semver": {
+              "version": "5.3.0",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sntp": {
+              "version": "1.0.9",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "hoek": "2.16.3"
+              }
+            },
+            "sshpk": {
+              "version": "1.13.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "asn1": "0.2.3",
+                "assert-plus": "1.0.0",
+                "bcrypt-pbkdf": "1.0.1",
+                "dashdash": "1.14.1",
+                "ecc-jsbn": "0.1.1",
+                "getpass": "0.1.7",
+                "jodid25519": "1.0.2",
+                "jsbn": "0.1.1",
+                "tweetnacl": "0.14.5"
+              },
+              "dependencies": {
+                "assert-plus": {
+                  "version": "1.0.0",
+                  "bundled": true,
+                  "optional": true
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "requires": {
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "bundled": true,
+              "optional": true
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "requires": {
+                "ansi-regex": "2.1.1"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "block-stream": "0.0.9",
+                "fstream": "1.0.11",
+                "inherits": "2.0.3"
+              }
+            },
+            "tar-pack": {
+              "version": "3.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "2.6.8",
+                "fstream": "1.0.11",
+                "fstream-ignore": "1.0.5",
+                "once": "1.4.0",
+                "readable-stream": "2.2.9",
+                "rimraf": "2.6.1",
+                "tar": "2.2.1",
+                "uid-number": "0.0.6"
+              }
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "punycode": "1.4.1"
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "5.0.1"
+              }
+            },
+            "tweetnacl": {
+              "version": "0.14.5",
+              "bundled": true,
+              "optional": true
+            },
+            "uid-number": {
+              "version": "0.0.6",
+              "bundled": true,
+              "optional": true
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "uuid": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "verror": {
+              "version": "1.3.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "extsprintf": "1.0.2"
+              }
+            },
+            "wide-align": {
+              "version": "1.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "1.0.2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true
+            }
+          }
+        },
+        "function-bind": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "is-property": "1.0.2"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "get-comments": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "git-up": {
+          "version": "2.0.8",
+          "bundled": true,
+          "requires": {
+            "is-ssh": "1.3.0",
+            "parse-url": "1.3.11"
+          }
+        },
+        "git-url-parse": {
+          "version": "6.2.2",
+          "bundled": true,
+          "requires": {
+            "git-up": "2.0.8"
+          }
+        },
+        "github-slugger": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "emoji-regex": "6.4.3"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.3",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "glob-base": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "glob-parent": "2.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-parent": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "is-glob": "2.0.1"
+          }
+        },
+        "glob-stream": {
+          "version": "5.3.5",
+          "bundled": true,
+          "requires": {
+            "extend": "3.0.1",
+            "glob": "5.0.15",
+            "glob-parent": "3.1.0",
+            "micromatch": "2.3.11",
+            "ordered-read-streams": "0.3.0",
+            "through2": "0.6.5",
+            "to-absolute-glob": "0.1.1",
+            "unique-stream": "2.2.1"
+          },
+          "dependencies": {
+            "glob": {
+              "version": "5.0.15",
+              "bundled": true,
+              "requires": {
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.3",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+              }
+            },
+            "glob-parent": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-glob": "3.1.0",
+                "path-dirname": "1.0.2"
+              }
+            },
+            "is-extglob": {
+              "version": "2.1.1",
+              "bundled": true
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "2.1.1"
+              }
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "readable-stream": {
+              "version": "1.0.34",
+              "bundled": true,
+              "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "0.0.1",
+                "string_decoder": "0.10.31"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            },
+            "through2": {
+              "version": "0.6.5",
+              "bundled": true,
+              "requires": {
+                "readable-stream": "1.0.34",
+                "xtend": "4.0.1"
+              }
+            }
+          }
+        },
+        "glob-to-regexp": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "globals": {
+          "version": "9.17.0",
+          "bundled": true
+        },
+        "globals-docs": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "globby": {
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "gulp-sourcemaps": {
+          "version": "1.6.0",
+          "bundled": true,
+          "requires": {
+            "convert-source-map": "1.5.0",
+            "graceful-fs": "4.1.11",
+            "strip-bom": "2.0.0",
+            "through2": "2.0.3",
+            "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "vinyl": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              }
+            }
+          }
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "function-bind": "1.1.0"
+          }
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "hash.js": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "hasprop": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "tape": "3.6.1"
+          },
+          "dependencies": {
+            "deep-equal": {
+              "version": "0.2.2",
+              "bundled": true
+            },
+            "defined": {
+              "version": "0.0.0",
+              "bundled": true
+            },
+            "glob": {
+              "version": "3.2.11",
+              "bundled": true,
+              "requires": {
+                "inherits": "2.0.3",
+                "minimatch": "0.3.0"
+              }
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "bundled": true,
+              "requires": {
+                "lru-cache": "2.7.3",
+                "sigmund": "1.0.1"
+              }
+            },
+            "object-inspect": {
+              "version": "0.4.0",
+              "bundled": true
+            },
+            "tape": {
+              "version": "3.6.1",
+              "bundled": true,
+              "requires": {
+                "deep-equal": "0.2.2",
+                "defined": "0.0.0",
+                "glob": "3.2.11",
+                "inherits": "2.0.3",
+                "object-inspect": "0.4.0",
+                "resumer": "0.0.0",
+                "through": "2.3.8"
+              }
+            }
+          }
+        },
+        "hast-util-is-element": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "hast-util-sanitize": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "xtend": "4.0.1"
+          }
+        },
+        "hast-util-to-html": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ccount": "1.0.1",
+            "comma-separated-tokens": "1.0.4",
+            "hast-util-is-element": "1.0.0",
+            "hast-util-whitespace": "1.0.0",
+            "html-void-elements": "1.0.2",
+            "kebab-case": "1.0.0",
+            "property-information": "3.2.0",
+            "space-separated-tokens": "1.1.1",
+            "stringify-entities": "1.3.1",
+            "unist-util-is": "2.1.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "hast-util-whitespace": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "highlight.js": {
+          "version": "9.12.0",
+          "bundled": true
+        },
+        "hmac-drbg": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "hash.js": "1.0.3",
+            "minimalistic-assert": "1.0.0",
+            "minimalistic-crypto-utils": "1.0.1"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "home-or-tmp": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "bundled": true
+        },
+        "html-void-elements": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "htmlescape": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "http-errors": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "depd": "1.1.0",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": "1.3.1"
+          }
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "iconv-lite": {
+          "version": "0.4.17",
+          "bundled": true
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "ignore": {
+          "version": "3.3.0",
+          "bundled": true
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "bundled": true
+        },
+        "indexof": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "inline-source-map": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "bundled": true,
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "ansi-regex": "2.1.1",
+            "chalk": "1.1.3",
+            "cli-cursor": "1.0.2",
+            "cli-width": "2.1.0",
+            "figures": "1.7.0",
+            "lodash": "4.17.4",
+            "readline2": "1.0.1",
+            "run-async": "0.1.0",
+            "rx-lite": "3.1.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "insert-module-globals": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "combine-source-map": "0.7.2",
+            "concat-stream": "1.5.2",
+            "is-buffer": "1.1.5",
+            "JSONStream": "1.3.1",
+            "lexical-scope": "1.2.0",
+            "process": "0.11.10",
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "interpret": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "bundled": true,
+          "requires": {
+            "loose-envify": "1.3.1"
+          }
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "ipaddr.js": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "irregular-plurals": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "is-absolute": {
+          "version": "0.2.6",
+          "bundled": true,
+          "requires": {
+            "is-relative": "0.2.1",
+            "is-windows": "0.2.0"
+          }
+        },
+        "is-alphabetical": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-alphanumeric": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-alphanumerical": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-alphabetical": "1.0.0",
+            "is-decimal": "1.0.0"
+          }
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-binary-path": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "binary-extensions": "1.8.0"
+          }
+        },
+        "is-buffer": {
+          "version": "1.1.5",
+          "bundled": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "is-date-object": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-decimal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-dotfile": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "is-equal-shallow": {
+          "version": "0.1.3",
+          "bundled": true,
+          "requires": {
+            "is-primitive": "2.0.0"
+          }
+        },
+        "is-extendable": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-extglob": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-finite": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-function": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-extglob": "1.0.0"
+          }
+        },
+        "is-hexadecimal": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-my-json-valid": {
+          "version": "2.16.0",
+          "bundled": true,
+          "requires": {
+            "generate-function": "2.0.0",
+            "generate-object-property": "1.2.0",
+            "jsonpointer": "4.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "is-number": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "kind-of": "3.2.2"
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "is-path-inside": "1.0.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "path-is-inside": "1.0.2"
+          }
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-posix-bracket": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "is-primitive": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "is-promise": {
+          "version": "2.1.0",
+          "bundled": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "is-regex": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "has": "1.0.1"
+          }
+        },
+        "is-relative": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "is-unc-path": "0.1.2"
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "tryit": "1.0.3"
+          }
+        },
+        "is-ssh": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "protocols": "1.4.5"
+          }
+        },
+        "is-stream": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "is-symbol": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-unc-path": {
+          "version": "0.1.2",
+          "bundled": true,
+          "requires": {
+            "unc-path-regex": "0.1.2"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "is-valid-glob": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "is-whitespace-character": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "is-windows": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "is-word-character": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isobject": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "isarray": "1.0.0"
+          }
+        },
+        "isomorphic-fetch": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "node-fetch": "1.6.3",
+            "whatwg-fetch": "2.0.3"
+          }
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "js-tokens": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "js-yaml": {
+          "version": "3.8.4",
+          "bundled": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "3.1.3"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsesc": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "json5": {
+          "version": "0.5.1",
+          "bundled": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "jsonparse": {
+          "version": "1.3.0",
+          "bundled": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.0",
+            "through": "2.3.8"
+          }
+        },
+        "jsontokens": {
+          "version": "0.7.6",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "4.9.1",
+            "base64url": "2.0.0",
+            "crypto": "0.0.3",
+            "elliptic": "6.4.0",
+            "key-encoder": "1.1.6",
+            "validator": "7.0.0"
+          }
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "kebab-case": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "key-encoder": {
+          "version": "1.1.6",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "2.2.1",
+            "bn.js": "3.3.0",
+            "elliptic": "5.2.1"
+          },
+          "dependencies": {
+            "asn1.js": {
+              "version": "2.2.1",
+              "bundled": true,
+              "requires": {
+                "bn.js": "2.2.0",
+                "inherits": "2.0.3",
+                "minimalistic-assert": "1.0.0"
+              },
+              "dependencies": {
+                "bn.js": {
+                  "version": "2.2.0",
+                  "bundled": true
+                }
+              }
+            },
+            "bn.js": {
+              "version": "3.3.0",
+              "bundled": true
+            },
+            "elliptic": {
+              "version": "5.2.1",
+              "bundled": true,
+              "requires": {
+                "bn.js": "3.3.0",
+                "brorand": "1.1.0",
+                "hash.js": "1.0.3",
+                "inherits": "2.0.3"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "3.2.2",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "1.1.5"
+          }
+        },
+        "labeled-stream-splicer": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "stream-splicer": "2.0.0"
+          },
+          "dependencies": {
+            "isarray": {
+              "version": "0.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "lazystream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.2.9"
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
+        },
+        "lexical-scope": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "astw": "2.2.0"
+          }
+        },
+        "livereload-js": {
+          "version": "2.2.2",
+          "bundled": true
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
+          },
+          "dependencies": {
+            "path-exists": {
+              "version": "3.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "bundled": true
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "bundled": true
+        },
+        "lodash.cond": {
+          "version": "4.5.2",
+          "bundled": true
+        },
+        "lodash.endswith": {
+          "version": "4.2.1",
+          "bundled": true
+        },
+        "lodash.find": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.findindex": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "bundled": true
+        },
+        "lodash.memoize": {
+          "version": "3.0.4",
+          "bundled": true
+        },
+        "lodash.pickby": {
+          "version": "4.6.0",
+          "bundled": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        },
+        "longest-streak": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "js-tokens": "3.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "2.7.3",
+          "bundled": true
+        },
+        "map-cache": {
+          "version": "0.2.2",
+          "bundled": true
+        },
+        "markdown-escapes": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "markdown-table": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "mdast-util-compact": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "unist-util-modify-children": "1.1.1",
+            "unist-util-visit": "1.1.3"
+          }
+        },
+        "mdast-util-definitions": {
+          "version": "1.2.2",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "1.1.3"
+          }
+        },
+        "mdast-util-inject": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "mdast-util-to-string": "1.0.4"
+          }
+        },
+        "mdast-util-to-hast": {
+          "version": "2.4.2",
+          "bundled": true,
+          "requires": {
+            "collapse-white-space": "1.0.3",
+            "detab": "2.0.0",
+            "mdast-util-definitions": "1.2.2",
+            "normalize-uri": "1.1.0",
+            "trim": "0.0.1",
+            "trim-lines": "1.1.0",
+            "unist-builder": "1.0.2",
+            "unist-util-generated": "1.1.1",
+            "unist-util-position": "3.0.0",
+            "unist-util-visit": "1.1.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "mdast-util-to-string": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "mdast-util-toc": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "github-slugger": "1.1.1",
+            "mdast-util-to-string": "1.0.4",
+            "unist-util-visit": "1.1.3"
+          }
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "bundled": true
+        },
+        "merge-descriptors": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "merge-stream": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.2.9"
+          }
+        },
+        "methods": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "micromatch": {
+          "version": "2.3.11",
+          "bundled": true,
+          "requires": {
+            "arr-diff": "2.0.0",
+            "array-unique": "0.2.1",
+            "braces": "1.8.5",
+            "expand-brackets": "0.1.5",
+            "extglob": "0.3.2",
+            "filename-regex": "2.0.1",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1",
+            "kind-of": "3.2.2",
+            "normalize-path": "2.1.1",
+            "object.omit": "2.0.1",
+            "parse-glob": "3.0.4",
+            "regex-cache": "0.4.3"
+          }
+        },
+        "miller-rabin": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "brorand": "1.1.0"
+          }
+        },
+        "mime": {
+          "version": "1.3.4",
+          "bundled": true
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "minimalistic-assert": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "minimalistic-crypto-utils": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "module-deps": {
+          "version": "4.1.1",
+          "bundled": true,
+          "requires": {
+            "browser-resolve": "1.11.2",
+            "cached-path-relative": "1.0.1",
+            "concat-stream": "1.5.2",
+            "defined": "1.0.0",
+            "detective": "4.5.0",
+            "duplexer2": "0.1.4",
+            "inherits": "2.0.3",
+            "JSONStream": "1.3.1",
+            "parents": "1.0.1",
+            "readable-stream": "2.2.9",
+            "resolve": "1.1.7",
+            "stream-combiner2": "1.1.1",
+            "subarg": "1.0.0",
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.3",
+          "bundled": true
+        },
+        "mute-stream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "nan": {
+          "version": "2.6.2",
+          "bundled": true,
+          "optional": true
+        },
+        "negotiator": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "node-fetch": {
+          "version": "1.6.3",
+          "bundled": true,
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "bundled": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.3.0",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "remove-trailing-separator": "1.0.2"
+          }
+        },
+        "normalize-uri": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true
+        },
+        "object-inspect": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "object-keys": {
+          "version": "1.0.11",
+          "bundled": true
+        },
+        "object.omit": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "for-own": "0.1.5",
+            "is-extendable": "0.1.1"
+          }
+        },
+        "on-finished": {
+          "version": "2.3.0",
+          "bundled": true,
+          "requires": {
+            "ee-first": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "onetime": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "opn": {
+          "version": "4.0.2",
+          "bundled": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "bundled": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "2.0.6",
+            "levn": "0.3.0",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "1.0.0"
+          }
+        },
+        "ordered-read-streams": {
+          "version": "0.3.0",
+          "bundled": true,
+          "requires": {
+            "is-stream": "1.1.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "output-file-sync": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1"
+          }
+        },
+        "p-limit": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "p-limit": "1.1.0"
+          }
+        },
+        "pako": {
+          "version": "0.2.9",
+          "bundled": true
+        },
+        "parents": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "path-platform": "0.11.15"
+          }
+        },
+        "parse-asn1": {
+          "version": "5.1.0",
+          "bundled": true,
+          "requires": {
+            "asn1.js": "4.9.1",
+            "browserify-aes": "1.0.6",
+            "create-hash": "1.1.2",
+            "evp_bytestokey": "1.0.0",
+            "pbkdf2": "3.0.9"
+          }
+        },
+        "parse-entities": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "character-entities": "1.2.0",
+            "character-entities-legacy": "1.1.0",
+            "character-reference-invalid": "1.1.0",
+            "is-alphanumerical": "1.0.0",
+            "is-decimal": "1.0.0",
+            "is-hexadecimal": "1.0.0"
+          }
+        },
+        "parse-filepath": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "is-absolute": "0.2.6",
+            "map-cache": "0.2.2",
+            "path-root": "0.1.1"
+          }
+        },
+        "parse-git-config": {
+          "version": "0.2.0",
+          "bundled": true,
+          "requires": {
+            "ini": "1.3.4"
+          }
+        },
+        "parse-glob": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "glob-base": "0.3.0",
+            "is-dotfile": "1.0.3",
+            "is-extglob": "1.0.0",
+            "is-glob": "2.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "parse-url": {
+          "version": "1.3.11",
+          "bundled": true,
+          "requires": {
+            "is-ssh": "1.3.0",
+            "protocols": "1.4.5"
+          }
+        },
+        "parseurl": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "path-dirname": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "path-platform": {
+          "version": "0.11.15",
+          "bundled": true
+        },
+        "path-root": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "path-root-regex": "0.1.2"
+          }
+        },
+        "path-root-regex": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "path-to-regexp": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "pify": "2.3.0"
+          }
+        },
+        "pbkdf2": {
+          "version": "3.0.9",
+          "bundled": true,
+          "requires": {
+            "create-hmac": "1.1.4"
+          }
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "pify": {
+          "version": "2.3.0",
+          "bundled": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "bundled": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "pkg-dir": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        },
+        "pkg-up": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "1.1.2"
+          }
+        },
+        "plur": {
+          "version": "2.1.2",
+          "bundled": true,
+          "requires": {
+            "irregular-plurals": "1.2.0"
+          }
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "prelude-ls": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "preserve": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "private": {
+          "version": "0.1.7",
+          "bundled": true
+        },
+        "process": {
+          "version": "0.11.10",
+          "bundled": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "progress": {
+          "version": "1.1.8",
+          "bundled": true
+        },
+        "promise": {
+          "version": "7.1.1",
+          "bundled": true,
+          "requires": {
+            "asap": "2.0.5"
+          }
+        },
+        "property-information": {
+          "version": "3.2.0",
+          "bundled": true
+        },
+        "protocols": {
+          "version": "1.4.5",
+          "bundled": true
+        },
+        "proxy-addr": {
+          "version": "1.1.4",
+          "bundled": true,
+          "requires": {
+            "forwarded": "0.1.0",
+            "ipaddr.js": "1.3.0"
+          }
+        },
+        "public-encrypt": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "bn.js": "4.11.6",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.1.2",
+            "parse-asn1": "5.1.0",
+            "randombytes": "2.0.3"
+          }
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true
+        },
+        "query-string": {
+          "version": "4.3.4",
+          "bundled": true,
+          "requires": {
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
+          }
+        },
+        "querystring": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "randomatic": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
+          },
+          "dependencies": {
+            "is-number": {
+              "version": "3.0.0",
+              "bundled": true,
+              "requires": {
+                "kind-of": "3.2.2"
+              },
+              "dependencies": {
+                "kind-of": {
+                  "version": "3.2.2",
+                  "bundled": true,
+                  "requires": {
+                    "is-buffer": "1.1.5"
+                  }
+                }
+              }
+            },
+            "kind-of": {
+              "version": "4.0.0",
+              "bundled": true,
+              "requires": {
+                "is-buffer": "1.1.5"
+              }
+            }
+          }
+        },
+        "randombytes": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "bundled": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "bytes": "1.0.0",
+            "string_decoder": "0.10.31"
+          },
+          "dependencies": {
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "read-only-stream": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.2.9"
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "load-json-file": "2.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "2.1.0",
+              "bundled": true,
+              "requires": {
+                "locate-path": "2.0.0"
+              }
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.0",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "readdirp": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "minimatch": "3.0.3",
+            "readable-stream": "2.2.9",
+            "set-immediate-shim": "1.0.1"
+          }
+        },
+        "readline2": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "mute-stream": "0.0.5"
+          }
+        },
+        "rechoir": {
+          "version": "0.6.2",
+          "bundled": true,
+          "requires": {
+            "resolve": "1.1.7"
+          }
+        },
+        "regenerate": {
+          "version": "1.3.2",
+          "bundled": true
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "bundled": true
+        },
+        "regenerator-transform": {
+          "version": "0.9.11",
+          "bundled": true,
+          "requires": {
+            "babel-runtime": "6.23.0",
+            "babel-types": "6.24.1",
+            "private": "0.1.7"
+          }
+        },
+        "regex-cache": {
+          "version": "0.4.3",
+          "bundled": true,
+          "requires": {
+            "is-equal-shallow": "0.1.3",
+            "is-primitive": "2.0.0"
+          }
+        },
+        "regexpu-core": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "regenerate": "1.3.2",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
+          }
+        },
+        "regjsgen": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "regjsparser": {
+          "version": "0.1.5",
+          "bundled": true,
+          "requires": {
+            "jsesc": "0.5.0"
+          },
+          "dependencies": {
+            "jsesc": {
+              "version": "0.5.0",
+              "bundled": true
+            }
+          }
+        },
+        "remark": {
+          "version": "7.0.1",
+          "bundled": true,
+          "requires": {
+            "remark-parse": "3.0.1",
+            "remark-stringify": "3.0.1",
+            "unified": "6.1.5"
+          }
+        },
+        "remark-html": {
+          "version": "6.0.0",
+          "bundled": true,
+          "requires": {
+            "hast-util-sanitize": "1.1.1",
+            "hast-util-to-html": "3.0.1",
+            "mdast-util-to-hast": "2.4.2",
+            "xtend": "4.0.1"
+          }
+        },
+        "remark-parse": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "collapse-white-space": "1.0.3",
+            "has": "1.0.1",
+            "is-alphabetical": "1.0.0",
+            "is-decimal": "1.0.0",
+            "is-whitespace-character": "1.0.0",
+            "is-word-character": "1.0.0",
+            "markdown-escapes": "1.0.0",
+            "parse-entities": "1.1.1",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "1.1.0",
+            "unherit": "1.1.0",
+            "unist-util-remove-position": "1.1.1",
+            "vfile-location": "2.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "remark-slug": {
+          "version": "4.2.3",
+          "bundled": true,
+          "requires": {
+            "github-slugger": "1.1.1",
+            "mdast-util-to-string": "1.0.4",
+            "unist-util-visit": "1.1.3"
+          }
+        },
+        "remark-stringify": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ccount": "1.0.1",
+            "is-alphanumeric": "1.0.0",
+            "is-decimal": "1.0.0",
+            "is-whitespace-character": "1.0.0",
+            "longest-streak": "2.0.1",
+            "markdown-escapes": "1.0.0",
+            "markdown-table": "1.1.0",
+            "mdast-util-compact": "1.0.1",
+            "parse-entities": "1.1.1",
+            "repeat-string": "1.6.1",
+            "state-toggle": "1.0.0",
+            "stringify-entities": "1.3.1",
+            "unherit": "1.1.0",
+            "xtend": "4.0.1"
+          }
+        },
+        "remark-toc": {
+          "version": "4.0.1",
+          "bundled": true,
+          "requires": {
+            "mdast-util-toc": "2.0.1",
+            "remark-slug": "4.2.3"
+          }
+        },
+        "remote-origin-url": {
+          "version": "0.4.0",
+          "bundled": true,
+          "requires": {
+            "parse-git-config": "0.2.0"
+          }
+        },
+        "remove-trailing-separator": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "repeat-element": {
+          "version": "1.1.2",
+          "bundled": true
+        },
+        "repeat-string": {
+          "version": "1.6.1",
+          "bundled": true
+        },
+        "repeating": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-finite": "1.0.2"
+          }
+        },
+        "replace-ext": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "bundled": true,
+          "requires": {
+            "caller-path": "0.1.0",
+            "resolve-from": "1.0.1"
+          }
+        },
+        "resolve": {
+          "version": "1.1.7",
+          "bundled": true
+        },
+        "resolve-from": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "restore-cursor": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "exit-hook": "1.1.1",
+            "onetime": "1.1.0"
+          }
+        },
+        "resumer": {
+          "version": "0.0.0",
+          "bundled": true,
+          "requires": {
+            "through": "2.3.8"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.1"
+          }
+        },
+        "ripemd160": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0"
+          }
+        },
+        "rx-lite": {
+          "version": "3.1.2",
+          "bundled": true
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "safe-json-parse": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "schema-inspector": {
+          "version": "1.6.8",
+          "bundled": true,
+          "requires": {
+            "async": "1.5.2"
+          }
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true
+        },
+        "send": {
+          "version": "0.15.1",
+          "bundled": true,
+          "requires": {
+            "debug": "2.6.1",
+            "depd": "1.1.0",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "etag": "1.8.0",
+            "fresh": "0.5.0",
+            "http-errors": "1.6.1",
+            "mime": "1.3.4",
+            "ms": "0.7.2",
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.0",
+            "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.1",
+              "bundled": true,
+              "requires": {
+                "ms": "0.7.2"
+              }
+            },
+            "ms": {
+              "version": "0.7.2",
+              "bundled": true
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.12.1",
+          "bundled": true,
+          "requires": {
+            "encodeurl": "1.0.1",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.1",
+            "send": "0.15.1"
+          }
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "set-immediate-shim": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sha.js": {
+          "version": "2.4.8",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "shasum": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "json-stable-stringify": "0.0.1",
+            "sha.js": "2.4.8"
+          },
+          "dependencies": {
+            "json-stable-stringify": {
+              "version": "0.0.1",
+              "bundled": true,
+              "requires": {
+                "jsonify": "0.0.0"
+              }
+            }
+          }
+        },
+        "shell-quote": {
+          "version": "1.6.1",
+          "bundled": true,
+          "requires": {
+            "array-filter": "0.0.1",
+            "array-map": "0.0.0",
+            "array-reduce": "0.0.0",
+            "jsonify": "0.0.0"
+          }
+        },
+        "shelljs": {
+          "version": "0.6.1",
+          "bundled": true
+        },
+        "sigmund": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "slash": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "slice-ansi": {
+          "version": "0.0.4",
+          "bundled": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "bundled": true
+        },
+        "source-map-support": {
+          "version": "0.4.15",
+          "bundled": true,
+          "requires": {
+            "source-map": "0.5.6"
+          }
+        },
+        "space-separated-tokens": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "trim": "0.0.1"
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "bundled": true
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "state-toggle": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "statuses": {
+          "version": "1.3.1",
+          "bundled": true
+        },
+        "stream-array": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.1.5"
+          },
+          "dependencies": {
+            "readable-stream": {
+              "version": "2.1.5",
+              "bundled": true,
+              "requires": {
+                "buffer-shims": "1.0.0",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "1.0.7",
+                "string_decoder": "0.10.31",
+                "util-deprecate": "1.0.2"
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "bundled": true
+            }
+          }
+        },
+        "stream-browserify": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "stream-combiner2": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "duplexer2": "0.1.4",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "stream-http": {
+          "version": "2.7.0",
+          "bundled": true,
+          "requires": {
+            "builtin-status-codes": "3.0.0",
+            "inherits": "2.0.3",
+            "readable-stream": "2.2.9",
+            "to-arraybuffer": "1.0.1",
+            "xtend": "4.0.1"
+          }
+        },
+        "stream-shift": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "stream-splicer": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "strict-uri-encode": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "string_decoder": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0"
+          }
+        },
+        "string-template": {
+          "version": "0.2.1",
+          "bundled": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string.prototype.trim": {
+          "version": "1.1.2",
+          "bundled": true,
+          "requires": {
+            "define-properties": "1.1.2",
+            "es-abstract": "1.7.0",
+            "function-bind": "1.1.0"
+          }
+        },
+        "stringify-entities": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "character-entities-html4": "1.1.0",
+            "character-entities-legacy": "1.1.0",
+            "is-alphanumerical": "1.0.0",
+            "is-hexadecimal": "1.0.0"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "strip-bom-stream": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "first-chunk-stream": "1.0.0",
+            "strip-bom": "2.0.0"
+          },
+          "dependencies": {
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "subarg": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "minimist": "1.2.0"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "syntax-error": {
+          "version": "1.3.0",
+          "bundled": true,
+          "requires": {
+            "acorn": "4.0.11"
+          }
+        },
+        "table": {
+          "version": "3.8.3",
+          "bundled": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "ajv-keywords": "1.5.1",
+            "chalk": "1.1.3",
+            "lodash": "4.17.4",
+            "slice-ansi": "0.0.4",
+            "string-width": "2.0.0"
+          },
+          "dependencies": {
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "bundled": true
+            },
+            "string-width": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "3.0.1"
+              }
+            }
+          }
+        },
+        "tape": {
+          "version": "4.6.3",
+          "bundled": true,
+          "requires": {
+            "deep-equal": "1.0.1",
+            "defined": "1.0.0",
+            "for-each": "0.3.2",
+            "function-bind": "1.1.0",
+            "glob": "7.1.1",
+            "has": "1.0.1",
+            "inherits": "2.0.3",
+            "minimist": "1.2.0",
+            "object-inspect": "1.2.2",
+            "resolve": "1.1.7",
+            "resumer": "0.0.0",
+            "string.prototype.trim": "1.1.2",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true
+            }
+          }
+        },
+        "tape-promise": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "is-promise": "2.1.0",
+            "onetime": "2.0.1"
+          },
+          "dependencies": {
+            "onetime": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "mimic-fn": "1.1.0"
+              }
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "bundled": true
+        },
+        "through": {
+          "version": "2.3.8",
+          "bundled": true
+        },
+        "through2": {
+          "version": "2.0.3",
+          "bundled": true,
+          "requires": {
+            "readable-stream": "2.2.9",
+            "xtend": "4.0.1"
+          }
+        },
+        "through2-filter": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "through2": "2.0.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "timers-browserify": {
+          "version": "1.4.2",
+          "bundled": true,
+          "requires": {
+            "process": "0.11.10"
+          }
+        },
+        "tiny-lr": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "body": "5.1.0",
+            "debug": "2.6.8",
+            "faye-websocket": "0.10.0",
+            "livereload-js": "2.2.2",
+            "object-assign": "4.1.1",
+            "qs": "6.4.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "bundled": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            },
+            "ms": {
+              "version": "2.0.0",
+              "bundled": true
+            }
+          }
+        },
+        "to-absolute-glob": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "extend-shallow": "2.0.1"
+          }
+        },
+        "to-arraybuffer": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "to-fast-properties": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "trim": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "trim-lines": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "trim-right": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "trim-trailing-lines": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "trough": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "tryit": {
+          "version": "1.0.3",
+          "bundled": true
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "bundled": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "type-check": {
+          "version": "0.3.2",
+          "bundled": true,
+          "requires": {
+            "prelude-ls": "1.1.2"
+          }
+        },
+        "type-is": {
+          "version": "1.6.15",
+          "bundled": true,
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "2.1.15"
+          }
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "bundled": true
+        },
+        "typeforce": {
+          "version": "1.11.1",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "umd": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "unc-path-regex": {
+          "version": "0.1.2",
+          "bundled": true
+        },
+        "unherit": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "xtend": "4.0.1"
+          }
+        },
+        "unified": {
+          "version": "6.1.5",
+          "bundled": true,
+          "requires": {
+            "bail": "1.0.1",
+            "extend": "3.0.1",
+            "is-plain-obj": "1.1.0",
+            "trough": "1.0.0",
+            "vfile": "2.1.0",
+            "x-is-function": "1.0.4",
+            "x-is-string": "0.1.0"
+          }
+        },
+        "unique-stream": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "json-stable-stringify": "1.0.1",
+            "through2-filter": "2.0.0"
+          }
+        },
+        "unist-builder": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "object-assign": "4.1.1"
+          }
+        },
+        "unist-util-generated": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "unist-util-is": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "unist-util-modify-children": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "array-iterate": "1.1.1"
+          }
+        },
+        "unist-util-position": {
+          "version": "3.0.0",
+          "bundled": true
+        },
+        "unist-util-remove-position": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "unist-util-visit": "1.1.3"
+          }
+        },
+        "unist-util-stringify-position": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "unist-util-visit": {
+          "version": "1.1.3",
+          "bundled": true
+        },
+        "unpipe": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "url": {
+          "version": "0.11.0",
+          "bundled": true,
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          },
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "bundled": true
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.1"
+          },
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "bundled": true
+            }
+          }
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "v8flags": {
+          "version": "2.1.1",
+          "bundled": true,
+          "requires": {
+            "user-home": "1.1.1"
+          }
+        },
+        "vali-date": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "validator": {
+          "version": "7.0.0",
+          "bundled": true
+        },
+        "vary": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "vfile": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "is-buffer": "1.1.5",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "1.1.1"
+          }
+        },
+        "vfile-location": {
+          "version": "2.0.1",
+          "bundled": true
+        },
+        "vfile-reporter": {
+          "version": "3.0.0",
+          "bundled": true,
+          "requires": {
+            "chalk": "1.1.3",
+            "log-symbols": "1.0.2",
+            "plur": "2.1.2",
+            "repeat-string": "1.6.1",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "trim": "0.0.1",
+            "unist-util-stringify-position": "1.1.1"
+          }
+        },
+        "vfile-sort": {
+          "version": "2.0.0",
+          "bundled": true
+        },
+        "vinyl": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "clone": "2.1.1",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.0.0",
+            "remove-trailing-separator": "1.0.2",
+            "replace-ext": "1.0.0"
+          }
+        },
+        "vinyl-fs": {
+          "version": "2.4.4",
+          "bundled": true,
+          "requires": {
+            "duplexify": "3.5.0",
+            "glob-stream": "5.3.5",
+            "graceful-fs": "4.1.11",
+            "gulp-sourcemaps": "1.6.0",
+            "is-valid-glob": "0.3.0",
+            "lazystream": "1.0.0",
+            "lodash.isequal": "4.5.0",
+            "merge-stream": "1.0.1",
+            "mkdirp": "0.5.1",
+            "object-assign": "4.1.1",
+            "readable-stream": "2.2.9",
+            "strip-bom": "2.0.0",
+            "strip-bom-stream": "1.0.0",
+            "through2": "2.0.3",
+            "through2-filter": "2.0.0",
+            "vali-date": "1.0.0",
+            "vinyl": "1.2.0"
+          },
+          "dependencies": {
+            "clone": {
+              "version": "1.0.2",
+              "bundled": true
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "bundled": true
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            },
+            "vinyl": {
+              "version": "1.2.0",
+              "bundled": true,
+              "requires": {
+                "clone": "1.0.2",
+                "clone-stats": "0.0.1",
+                "replace-ext": "0.0.1"
+              }
+            }
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "bundled": true,
+          "requires": {
+            "indexof": "0.0.1"
+          }
+        },
+        "websocket-driver": {
+          "version": "0.6.5",
+          "bundled": true,
+          "requires": {
+            "websocket-extensions": "0.1.1"
+          }
+        },
+        "websocket-extensions": {
+          "version": "0.1.1",
+          "bundled": true
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wif": {
+          "version": "2.0.6",
+          "bundled": true,
+          "requires": {
+            "bs58check": "1.3.4"
+          }
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "write": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "0.5.1"
+          }
+        },
+        "x-is-function": {
+          "version": "1.0.4",
+          "bundled": true
+        },
+        "x-is-string": {
+          "version": "0.1.0",
+          "bundled": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "bundled": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "bundled": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "bundled": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          },
+          "dependencies": {
+            "load-json-file": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "strip-bom": "2.0.0"
+              }
+            },
+            "path-type": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "graceful-fs": "4.1.11",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+              }
+            },
+            "read-pkg": {
+              "version": "1.1.0",
+              "bundled": true,
+              "requires": {
+                "load-json-file": "1.1.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "1.1.0"
+              }
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "bundled": true,
+              "requires": {
+                "find-up": "1.1.2",
+                "read-pkg": "1.1.0"
+              }
+            },
+            "strip-bom": {
+              "version": "2.0.0",
+              "bundled": true,
+              "requires": {
+                "is-utf8": "0.2.1"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "4.2.1",
+          "bundled": true,
+          "requires": {
+            "camelcase": "3.0.0"
+          }
+        },
+        "zone-file": {
+          "version": "0.2.2",
+          "bundled": true
+        }
+      }
+    },
+    "bn.js": {
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.7.tgz",
+      "integrity": "sha512-LxFiV5mefv0ley0SzqkOPR1bC4EbpPx8LkOz5vMe/Yi15t5hzwgO/G+tc7wOtL4PZTYjwHu8JnEiSLumuSjSfA==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+      "dev": true
+    },
+    "browser-pack": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.0.2.tgz",
+      "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
+      "dev": true,
+      "requires": {
+        "combine-source-map": "0.7.2",
+        "defined": "1.0.0",
+        "JSONStream": "1.3.1",
+        "through2": "2.0.3",
+        "umd": "3.0.1"
+      }
+    },
+    "browser-resolve": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.1.7"
+      },
+      "dependencies": {
+        "resolve": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+          "dev": true
+        }
+      }
+    },
+    "browserify": {
+      "version": "14.4.0",
+      "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.4.0.tgz",
+      "integrity": "sha1-CJo0Y69Y0OSNjNQHCz90ZU1avKk=",
+      "dev": true,
+      "requires": {
+        "assert": "1.4.1",
+        "browser-pack": "6.0.2",
+        "browser-resolve": "1.11.2",
+        "browserify-zlib": "0.1.4",
+        "buffer": "5.0.6",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "console-browserify": "1.1.0",
+        "constants-browserify": "1.0.0",
+        "crypto-browserify": "3.11.1",
+        "defined": "1.0.0",
+        "deps-sort": "2.0.0",
+        "domain-browser": "1.1.7",
+        "duplexer2": "0.1.4",
+        "events": "1.1.1",
+        "glob": "7.1.2",
+        "has": "1.0.1",
+        "htmlescape": "1.1.1",
+        "https-browserify": "1.0.0",
+        "inherits": "2.0.3",
+        "insert-module-globals": "7.0.1",
+        "JSONStream": "1.3.1",
+        "labeled-stream-splicer": "2.0.0",
+        "module-deps": "4.1.1",
+        "os-browserify": "0.1.2",
+        "parents": "1.0.1",
+        "path-browserify": "0.0.0",
+        "process": "0.11.10",
+        "punycode": "1.4.1",
+        "querystring-es3": "0.2.1",
+        "read-only-stream": "2.0.0",
+        "readable-stream": "2.3.3",
+        "resolve": "1.3.3",
+        "shasum": "1.0.2",
+        "shell-quote": "1.6.1",
+        "stream-browserify": "2.0.1",
+        "stream-http": "2.7.2",
+        "string_decoder": "1.0.3",
+        "subarg": "1.0.0",
+        "syntax-error": "1.3.0",
+        "through2": "2.0.3",
+        "timers-browserify": "1.4.2",
+        "tty-browserify": "0.0.0",
+        "url": "0.11.0",
+        "util": "0.10.3",
+        "vm-browserify": "0.0.4",
+        "xtend": "4.0.1"
+      }
+    },
+    "browserify-aes": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+      "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+      "dev": true,
+      "requires": {
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-cipher": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+      "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+      "dev": true,
+      "requires": {
+        "browserify-aes": "1.0.6",
+        "browserify-des": "1.0.0",
+        "evp_bytestokey": "1.0.0"
+      }
+    },
+    "browserify-des": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+      "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "des.js": "1.0.0",
+        "inherits": "2.0.3"
+      }
+    },
+    "browserify-rsa": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "randombytes": "2.0.5"
+      }
+    },
+    "browserify-sign": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+      "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "elliptic": "6.4.0",
+        "inherits": "2.0.3",
+        "parse-asn1": "5.1.0"
+      }
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+      "dev": true,
+      "requires": {
+        "pako": "0.2.9"
+      }
+    },
+    "buffer": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.6.tgz",
+      "integrity": "sha1-LqZp9+7Atu2gWwj4tf9mGyhXNYg=",
+      "dev": true,
+      "requires": {
+        "base64-js": "1.2.1",
+        "ieee754": "1.1.8"
+      }
+    },
+    "buffer-xor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+      "dev": true
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+      "dev": true
+    },
+    "cached-path-relative": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
+      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
+      "dev": true
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "combine-source-map": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.7.2.tgz",
+      "integrity": "sha1-CHAxKFazB6h8xKxIbzqaYq7MwJ4=",
+      "dev": true,
+      "requires": {
+        "convert-source-map": "1.1.3",
+        "inline-source-map": "0.6.2",
+        "lodash.memoize": "3.0.4",
+        "source-map": "0.5.6"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
+      "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.0.6",
+        "typedarray": "0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "0.10.31",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+      "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
+      "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-ecdh": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+      "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "elliptic": "6.4.0"
+      }
+    },
+    "create-hash": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+      "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "create-hmac": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+      "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+      "dev": true,
+      "requires": {
+        "cipher-base": "1.0.4",
+        "create-hash": "1.1.3",
+        "inherits": "2.0.3",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "crypto-browserify": {
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+      "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+      "dev": true,
+      "requires": {
+        "browserify-cipher": "1.0.0",
+        "browserify-sign": "4.0.4",
+        "create-ecdh": "4.0.0",
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "diffie-hellman": "5.0.2",
+        "inherits": "2.0.3",
+        "pbkdf2": "3.0.12",
+        "public-encrypt": "4.0.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "depd": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+      "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
+      "dev": true
+    },
+    "deps-sort": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
+      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
+      "dev": true,
+      "requires": {
+        "JSONStream": "1.3.1",
+        "shasum": "1.0.2",
+        "subarg": "1.0.0",
+        "through2": "2.0.3"
+      }
+    },
+    "des.js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+      "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detective": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      }
+    },
+    "diffie-hellman": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+      "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "miller-rabin": "4.0.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+      "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+      "dev": true
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "elliptic": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+      "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.3",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "dev": true
+    },
+    "evp_bytestokey": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+      "integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3"
+      }
+    },
+    "express": {
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.3.tgz",
+      "integrity": "sha1-urZdDwOqgMNYQIly/HAPkWlEtmI=",
+      "dev": true,
+      "requires": {
+        "accepts": "1.3.3",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
+        "content-type": "1.0.2",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "finalhandler": "1.0.3",
+        "fresh": "0.5.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.4",
+        "qs": "6.4.0",
+        "range-parser": "1.2.0",
+        "send": "0.15.3",
+        "serve-static": "1.12.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1",
+        "type-is": "1.6.15",
+        "utils-merge": "1.0.0",
+        "vary": "1.1.1"
+      }
+    },
+    "finalhandler": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+      "integrity": "sha1-70fneVDpmXgOhgIqVg4yF+DQzIk=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "on-finished": "2.3.0",
+        "parseurl": "1.3.1",
+        "statuses": "1.3.1",
+        "unpipe": "1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
+      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.0"
+      }
+    },
+    "hash-base": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+      "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "minimalistic-assert": "1.0.0"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "dev": true,
+      "requires": {
+        "hash.js": "1.1.3",
+        "minimalistic-assert": "1.0.0",
+        "minimalistic-crypto-utils": "1.0.1"
+      }
+    },
+    "htmlescape": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
+      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+      "integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
+      "dev": true,
+      "requires": {
+        "depd": "1.1.0",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.0.3",
+        "statuses": "1.3.1"
+      }
+    },
+    "https-browserify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+      "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inline-source-map": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
+      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.6"
+      }
+    },
+    "insert-module-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.1.tgz",
+      "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
+      "dev": true,
+      "requires": {
+        "combine-source-map": "0.7.2",
+        "concat-stream": "1.5.2",
+        "is-buffer": "1.1.5",
+        "JSONStream": "1.3.1",
+        "lexical-scope": "1.2.0",
+        "process": "0.11.10",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "ipaddr.js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz",
+      "integrity": "sha1-HgOlL9rYOou7KyXL9JmLTP/NPew=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+      "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "json-stable-stringify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
+      "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+      "dev": true
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
+    "labeled-stream-splicer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-pS4dE4AkwAuGscDJH2d5GLiuClk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "isarray": "0.0.1",
+        "stream-splicer": "2.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
+    "lexical-scope": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
+      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
+      "dev": true,
+      "requires": {
+        "astw": "2.2.0"
+      }
+    },
+    "lodash.memoize": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
+      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "miller-rabin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+      "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "brorand": "1.1.0"
+      }
+    },
+    "mime": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.15",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.27.0"
+      }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+      "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+      "dev": true
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "module-deps": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
+      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
+      "dev": true,
+      "requires": {
+        "browser-resolve": "1.11.2",
+        "cached-path-relative": "1.0.1",
+        "concat-stream": "1.5.2",
+        "defined": "1.0.0",
+        "detective": "4.5.0",
+        "duplexer2": "0.1.4",
+        "inherits": "2.0.3",
+        "JSONStream": "1.3.1",
+        "parents": "1.0.1",
+        "readable-stream": "2.3.3",
+        "resolve": "1.3.3",
+        "stream-combiner2": "1.1.1",
+        "subarg": "1.0.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "node-localstorage": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.0.tgz",
+      "integrity": "sha1-LkNqro3Mms6XtDxlwWwNV3vgpVw=",
+      "dev": true,
+      "requires": {
+        "write-file-atomic": "1.3.4"
+      }
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "os-browserify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz",
+      "integrity": "sha1-ScoCk+CxlZCl9d4Qx/JlphfY/lQ=",
+      "dev": true
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+      "dev": true
+    },
+    "parents": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
+      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
+      "dev": true,
+      "requires": {
+        "path-platform": "0.11.15"
+      }
+    },
+    "parse-asn1": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+      "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+      "dev": true,
+      "requires": {
+        "asn1.js": "4.9.1",
+        "browserify-aes": "1.0.6",
+        "create-hash": "1.1.3",
+        "evp_bytestokey": "1.0.0",
+        "pbkdf2": "3.0.12"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+      "dev": true
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "path-platform": {
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
+      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "pbkdf2": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.12.tgz",
+      "integrity": "sha1-vjZ4XFBn6kjYBv+SMojF91C2uKI=",
+      "dev": true,
+      "requires": {
+        "create-hash": "1.1.3",
+        "create-hmac": "1.1.6",
+        "ripemd160": "2.0.1",
+        "safe-buffer": "5.1.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+      "integrity": "sha1-J+VF9pYKRKYn2bREZ+NcG2tM4vM=",
+      "dev": true,
+      "requires": {
+        "forwarded": "0.1.0",
+        "ipaddr.js": "1.3.0"
+      }
+    },
+    "public-encrypt": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+      "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+      "dev": true,
+      "requires": {
+        "bn.js": "4.11.7",
+        "browserify-rsa": "4.0.1",
+        "create-hash": "1.1.3",
+        "parse-asn1": "5.1.0",
+        "randombytes": "2.0.5"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "qs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+      "dev": true
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "dev": true
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+      "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+      "dev": true
+    },
+    "randombytes": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+      "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "read-only-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
+      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "resolve": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "ripemd160": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+      "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+      "dev": true,
+      "requires": {
+        "hash-base": "2.0.2",
+        "inherits": "2.0.3"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.3.tgz",
+      "integrity": "sha1-UBP5+ZAj31DRvZiSwZ4979HVMwk=",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.7",
+        "depd": "1.1.0",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.0",
+        "fresh": "0.5.0",
+        "http-errors": "1.6.1",
+        "mime": "1.3.4",
+        "ms": "2.0.0",
+        "on-finished": "2.3.0",
+        "range-parser": "1.2.0",
+        "statuses": "1.3.1"
+      }
+    },
+    "serve-static": {
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz",
+      "integrity": "sha1-n0uhni8wMMVH+K+ZEHg47DjVseI=",
+      "dev": true,
+      "requires": {
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "parseurl": "1.3.1",
+        "send": "0.15.3"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+      "dev": true
+    },
+    "sha.js": {
+      "version": "2.4.8",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+      "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3"
+      }
+    },
+    "shasum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
+      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
+      "dev": true,
+      "requires": {
+        "json-stable-stringify": "0.0.1",
+        "sha.js": "2.4.8"
+      }
+    },
+    "shell-quote": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
+      "dev": true,
+      "requires": {
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
+        "jsonify": "0.0.0"
+      }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+      "dev": true
+    },
+    "statuses": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+      "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+      "dev": true
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+      "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stream-combiner2": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
+      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
+      "dev": true,
+      "requires": {
+        "duplexer2": "0.1.4",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "stream-http": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+      "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+      "dev": true,
+      "requires": {
+        "builtin-status-codes": "3.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3",
+        "to-arraybuffer": "1.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "stream-splicer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
+      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.3"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0"
+      }
+    },
+    "syntax-error": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.3.0.tgz",
+      "integrity": "sha1-HtkmbE1AvnXcVb+bsct3Biu5bKE=",
+      "dev": true,
+      "requires": {
+        "acorn": "4.0.13"
+      }
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "timers-browserify": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
+      "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
+      "dev": true,
+      "requires": {
+        "process": "0.11.10"
+      }
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+      "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+      "dev": true
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+      "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "2.1.15"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "umd": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.1.tgz",
+      "integrity": "sha1-iuVW4RAR9jwllnCKiDclnwGz1g4=",
+      "dev": true
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+          "dev": true
+        }
+      }
+    },
+    "util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.1"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+      "dev": true
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+      "dev": true,
+      "requires": {
+        "indexof": "0.0.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "node-localstorage": "^1.3.0"
   },
   "dependencies": {
-    "blockstack": "0.7.0"
+    "blockstack": "0.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "node-localstorage": "^1.3.0"
   },
   "dependencies": {
-    "blockstack": "0.9.0"
+    "blockstack": "0.9.1"
   }
 }

--- a/public/app.js
+++ b/public/app.js
@@ -90,7 +90,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
   if (blockstack.isUserSignedIn()) {
     showProfile(blockstack.loadUserData())
   } else if (blockstack.isSignInPending()) {
-    blockstack.handlePendingSignIn()
+    blockstack.handlePendingSignIn('http://localhost:6270/v1/names/')
     .then((userData) => {
       window.location = window.location.origin
     }, () => {


### PR DESCRIPTION
Re-enables address/name verification and provides a method to set core node. Also enables use of storage without a blockchain id.